### PR TITLE
Migrate to napari plugin engine 2

### DIFF
--- a/napari_arboretum/_hookimpls.py
+++ b/napari_arboretum/_hookimpls.py
@@ -1,8 +1,5 @@
-from napari_plugin_engine import napari_hook_implementation
-
 from .plugin import Arboretum
 
 
-@napari_hook_implementation
 def napari_experimental_provide_dock_widget():
     return Arboretum

--- a/napari_arboretum/napari.yaml
+++ b/napari_arboretum/napari.yaml
@@ -1,0 +1,10 @@
+name: napari-arboretum
+schema_version: 0.1.0
+contributions:
+  commands:
+  - id: napari-arboretum.Arboretum
+    title: Create Arboretum
+    python_name: napari_arboretum._hookimpls:Arboretum
+  widgets:
+  - command: napari-arboretum.Arboretum
+    display_name: Arboretum

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,10 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: BSD License",
     ],
-    entry_points={"napari.plugin": ["napari-arboretum = napari_arboretum"]},
+    entry_points={
+        "napari.manifest": [
+            "napari-arboretum = napari_arboretum:napari.yaml",
+        ],
+    },
+    package_data={"napari_arboretum": ["napari.yaml"]},
 )


### PR DESCRIPTION
This is a result of following the instructions on the [npe2 migration guide](https://napari.org/plugins/stable/npe2_migration_guide.html). To the unexperienced eye manually testing, the results look reasonable (it looks the same as before) - but I would encourage the reviewer to at least test a standard workflow with it.

@alessandrofelder; @paddyroddy