### PR TITLE
Refactor plotting code

### DIFF
--- a/napari_arboretum/_tests/test_plugin.py
+++ b/napari_arboretum/_tests/test_plugin.py
@@ -12,4 +12,6 @@ def test_plugin(make_napari_viewer):
     tracks, segmentation = load_sample_data()
 
     plugin = Arboretum(viewer)
-    plugin.draw_graph(tracks, track_id=140)
+    # Mock setting the tracks through mouse click
+    plugin.plotter.tracks = tracks
+    plugin.plotter.draw_tree(track_id=140)

--- a/napari_arboretum/graph.py
+++ b/napari_arboretum/graph.py
@@ -109,17 +109,17 @@ def build_subgraph(
 
     Parameters
     ----------
-    layer : napari.layers.Tracks
+    layer :
         A tracks layer.
-    search_node : int
+    search_node :
         The search node ID. Note that this may not be the root of the tree,
         therefore, we need to search all branches of all trees to find this.
 
     Returns
     -------
-    root_id : int, None
+    root_id :
         The root node ID of the tree which contains the node.
-    nodes : list[TreeNode]
+    nodes :
         The nodes of the subtree that contain the search node.
     """
     roots, reverse_graph = build_reverse_graph(layer.graph)

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -45,7 +45,7 @@ class Arboretum(QWidget):
         self.tracks_layers: List[napari.layers.Tracks] = []
         self.update_tracks_layers()
 
-    def update_tracks_layers(self, event=None):
+    def update_tracks_layers(self, event=None) -> None:
         """Get the Tracks layers that are present in the viewer."""
         layers = [
             layer
@@ -62,7 +62,7 @@ class Arboretum(QWidget):
 
         self.tracks_layers = layers
 
-    def append_mouse_callback(self, track_layer: napari.layers.Tracks):
+    def append_mouse_callback(self, track_layer: napari.layers.Tracks) -> None:
         """
         Add a mouse callback to ``track_layer`` to draw the tree
         when the layer is clicked.

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -1,24 +1,10 @@
-# ------------------------------------------------------------------------------
-# Name:     Arboretum
-# Purpose:  Dockable widget, and custom track visualization layers for Napari,
-#           to cell/object track data.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  01/05/2020
-# ------------------------------------------------------------------------------
-
 from typing import List
 
 import napari
-import numpy as np
-import pyqtgraph as pg
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QWidget
 
-from .graph import build_subgraph, layout_subgraph
+from .visualisation import PyQtGraphPlotter, TreePlotterQWidgetBase
 
 GUI_MAXIMUM_WIDTH = 600
 
@@ -42,113 +28,53 @@ class Arboretum(QWidget):
 
     def __init__(self, viewer: napari.Viewer, parent=None):
         super().__init__(parent=parent)
-
-        # store a reference to the viewer
-        self._viewer = viewer
+        self.viewer = viewer
+        self.plotter: TreePlotterQWidgetBase = PyQtGraphPlotter()
 
         # build the canvas to display the trees
         layout = QVBoxLayout()
-        plot_widget = pg.GraphicsLayoutWidget()
-        self.plot_view = plot_widget.addPlot(
-            title="Lineage tree", labels={"left": "Time"}
-        )
-        self.plot_view.hideAxis("bottom")
-        layout.addWidget(plot_widget)
+        layout.addWidget(self.plotter.get_qwidget())
         layout.setAlignment(Qt.AlignTop)
         layout.setSpacing(4)
         self.setMaximumWidth(GUI_MAXIMUM_WIDTH)
         self.setLayout(layout)
 
-        # hook up an event to find Tracks layers if the layer list changes
-        self._viewer.layers.events.changed.connect(self._get_tracks_layers)
+        # hook up an event to update the list of tracks layers if the layer
+        # list changes
+        self.viewer.layers.events.changed.connect(self.update_tracks_layers)
+        self.tracks_layers: List[napari.layers.Tracks] = []
+        self.update_tracks_layers()
 
-        # store the tracks layers
-        self._tracks_layers: List[napari.layers.Tracks] = []
-        self._get_tracks_layers()
-
-    def _get_tracks_layers(self, event=None):
+    def update_tracks_layers(self, event=None):
         """Get the Tracks layers that are present in the viewer."""
-
         layers = [
             layer
-            for layer in self._viewer.layers
+            for layer in self.viewer.layers
             if isinstance(layer, napari.layers.Tracks)
         ]
 
         for layer in layers:
-            if layer not in self._tracks_layers:
-                self._append_mouse_callback(layer)
-                layer.events.color_by.connect(self.draw_graph)
+            if layer not in self.tracks_layers:
+                # Add callback to draw graph when layer clicked
+                self.append_mouse_callback(layer)
+                # Add callback to change tree colours when layer colours changed
+                layer.events.color_by.connect(self.plotter.plot_branches)
 
-        self._tracks_layers = layers
+        self.tracks_layers = layers
 
-    def _append_mouse_callback(self, track_layer: napari.layers.Tracks) -> None:
+    def append_mouse_callback(self, track_layer: napari.layers.Tracks):
         """
-        Append a mouse callback to *track_layer* that:
-        - sets self.layer and self.track_id
-        - draws the graph
+        Add a mouse callback to ``track_layer`` to draw the tree
+        when the layer is clicked.
         """
 
         @track_layer.mouse_drag_callbacks.append
-        def show_tree(layer, event) -> None:
+        def show_tree(layer, event):
+            self.plotter.tracks = layer
+
             cursor_position = event.position
-            track_id = layer.get_value(cursor_position)
+            track_id = layer.get_value(cursor_position, world=True)
             if not track_id:
                 return
-            self.draw_graph(layer, track_id=track_id)
 
-    def update_colors(self):
-        """
-        Update colors on a list of edges from the colors they have in a
-        track layer. Note that this updates the colors in-place on ``edges``.
-        """
-        for e in self.edges:
-            if e.id is not None:
-                color = self.layer.track_colors[
-                    np.where(self.layer.properties["track_id"] == e.id)
-                ][-1]
-                # napari uses [0, 1] RGBA, pygraphqt uses [0, 255] RGBA
-                e.color = color * 255
-
-    def draw_graph(self, layer: napari.layers.Tracks, *, track_id: int) -> None:
-        """
-        Plot graph on the plugin canvas.
-        """
-        self.layer = layer
-        self.track_id = track_id
-        root, subgraph_nodes = build_subgraph(layer, track_id)
-        self.edges, self.annotations = layout_subgraph(root, subgraph_nodes)
-
-        self.update_colors()
-
-        self.plot_view.clear()
-        self.plot_view.setTitle(f"Lineage tree: {self.track_id}")
-
-        # NOTE(arl): disabling the autoranging improves perfomance dramatically
-        # https://stackoverflow.com/questions/17103698/plotting-large-arrays-in-pyqtgraph
-        self.plot_view.disableAutoRange()
-
-        for e in self.edges:
-            self.plot_view.plot(e.y, e.x, pen=pg.mkPen(color=e.color, width=3))
-
-        # labels
-        for a in self.annotations:
-
-            # change the alpha value according to whether this is the selected
-            # cell or another part of the tree
-            a.color[3] = 255 if a.label == str(self.track_id) else 64
-
-            pt = pg.TextItem(
-                text=a.label,
-                color=a.color,
-                html=None,
-                anchor=(0, 0),
-                border=None,
-                fill=None,
-                angle=0,
-                rotateAxis=None,
-            )
-            pt.setPos(a.x, a.y)
-            self.plot_view.addItem(pt, ignoreBounds=True)
-
-        self.plot_view.autoRange()
+            self.plotter.draw_tree(track_id)

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -12,18 +12,6 @@ GUI_MAXIMUM_WIDTH = 600
 class Arboretum(QWidget):
     """
     Tree viewer widget.
-
-    Parameters
-    ----------
-    viewer : napari.Viewer
-        Accepts the napari viewer.
-
-
-    Returns
-    -------
-    arboretum : QWidget
-        The arboretum widget.
-
     """
 
     def __init__(self, viewer: napari.Viewer, parent=None):
@@ -46,7 +34,9 @@ class Arboretum(QWidget):
         self.update_tracks_layers()
 
     def update_tracks_layers(self, event=None) -> None:
-        """Get the Tracks layers that are present in the viewer."""
+        """
+        Get the Tracks layers that are present in the viewer.
+        """
         layers = [
             layer
             for layer in self.viewer.layers

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -6,10 +6,11 @@ from napari.utils.colormaps import AVAILABLE_COLORMAPS
 
 # colormaps
 turbo = AVAILABLE_COLORMAPS["turbo"]
-WHITE = np.array([255, 255, 255, 255], dtype=np.uint8)
-RED = np.array([255, 0, 0, 255], dtype=np.uint8)
+WHITE = np.array([1, 1, 1, 1], dtype=float)
+RED = np.array([1, 0, 0, 1], dtype=float)
 
-# RGBA in range [0, 255]
+# napari specifies colours as a RGBA tuple in the range [0, 1], so mirror
+# that convention throughout arboretum.
 ColorType = Tuple[float, float, float, float]
 
 
@@ -69,7 +70,7 @@ def _build_tree(nodes) -> Tuple[List[Edge], List[Annotation]]:
 
         # TODO(arl): sync this with layer coloring
         depth = float(node.generation) / max_generational_depth
-        edge_color = turbo.map(depth)[0] * 255
+        edge_color = turbo.map(depth)[0]
 
         # draw the root of the tree
         edges.append(

--- a/napari_arboretum/visualisation/__init__.py
+++ b/napari_arboretum/visualisation/__init__.py
@@ -1,0 +1,14 @@
+"""
+Code for creating tree visualisations.
+
+`base_plotter` contains `TreePlotterBase`, a base class for plotting trees.
+This base class is backend independent, which means it does not depend on
+a specific plotting library (e.g. pyqtgraph, Matplotlib, vispy).
+
+To implement a usable plotting class `TreePlotterBase` can be inherited,
+and plotting-library-specific functionality defined in the abstract methods
+that must be implemented.
+"""
+
+from .base_plotter import *
+from .pyqtgraph_plotter import *

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -1,12 +1,11 @@
 import abc
-from typing import Sequence
 
 import napari
 import numpy as np
 from qtpy.QtWidgets import QWidget
 
 from ..graph import build_subgraph, layout_subgraph
-from ..tree import ColorType
+from ..tree import Annotation, Edge
 
 GUI_MAXIMUM_WIDTH = 600
 
@@ -53,9 +52,8 @@ class TreePlotterBase(abc.ABC):
         for a in self.annotations:
             # change the alpha value according to whether this is the selected
             # cell or another part of the tree
-            color = a.color
-            color[3] = 1 if a.label == str(track_id) else 0.25
-            self.add_annotation(a.x, a.y, a.label, a.color)
+            a.color[3] = 1 if a.label == str(track_id) else 0.25
+            self.add_annotation(a)
 
     def plot_branches(self) -> None:
         """
@@ -71,40 +69,20 @@ class TreePlotterBase(abc.ABC):
                 ]
                 # For a track that has colour varying along it, just select the
                 # first colour for now
-                color = color[-1, :]
-            else:
-                color = e.color
-            self.add_branch(e.x, e.y, color)
+                e.color = color[-1, :]
+            self.add_branch(e)
 
     @abc.abstractmethod
-    def add_branch(
-        self, x: Sequence[float], y: Sequence[float], color: ColorType
-    ) -> None:
+    def add_branch(self, e: Edge) -> None:
         """
         Add a single branch to the tree.
-
-        Parameters
-        ----------
-        x, y : Sequence[float]
-            x/y coordinates of the branch.
-        color : ColorType
-            Color in a RGBA tuple with values in the range [0, 1].
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def add_annotation(self, x: float, y: float, label: str, color: ColorType) -> None:
+    def add_annotation(self, a: Annotation) -> None:
         """
         Add a single label to the tree.
-
-        Parameters
-        ----------
-        x, y : float
-            x/y coordinate of the annotation.
-        label : str
-            Annotation text.
-        color : ColorType
-            Color in a RGBA tuple with values in the range [0, 1].
         """
         raise NotImplementedError()
 

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -93,7 +93,7 @@ class TreePlotterBase(abc.ABC):
 
         Parameters
         ----------
-        title : str
+        title :
             Plot title.
         """
         raise NotImplementedError()

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -1,0 +1,135 @@
+import abc
+from typing import Sequence
+
+import napari
+import numpy as np
+from qtpy.QtWidgets import QWidget
+
+from ..graph import build_subgraph, layout_subgraph
+from ..tree import ColorType
+
+GUI_MAXIMUM_WIDTH = 600
+
+__all__ = ["TreePlotterBase", "TreePlotterQWidgetBase"]
+
+
+class TreePlotterBase(abc.ABC):
+    """
+    Base class for a `napari.layers.Tracks` plotter.
+
+    This class is designed to handle the translation from a `napari.layers.Tracks`
+    layer to visual objects that can be plotted (e.g. lines, text). As such its
+    only state is the ``_tracks`` attribute.
+
+    This is not designed to actually render the plotting objects objects.
+    Sub-classes should do that by impelmenting the abstract methods defined below.
+    """
+
+    @property
+    def tracks(self) -> napari.layers.Tracks:
+        """
+        The napari tracks layer associated with this plotter.
+        """
+        if not hasattr(self, "_tracks"):
+            raise AttributeError("No tracks set on this plotter.")
+        return self._tracks
+
+    @tracks.setter
+    def tracks(self, track_layer: napari.layers.Tracks):
+        self._tracks = track_layer
+
+    def draw_tree(self, track_id: int) -> None:
+        """
+        Plot the tree containing ``track_id``.
+        """
+        root, subgraph_nodes = build_subgraph(self.tracks, track_id)
+        self.edges, self.annotations = layout_subgraph(root, subgraph_nodes)
+
+        self.set_title(f"Lineage tree: {track_id}")
+
+        self.plot_branches()
+
+        # labels
+        for a in self.annotations:
+            # change the alpha value according to whether this is the selected
+            # cell or another part of the tree
+            color = a.color
+            color[3] = 1 if a.label == str(track_id) else 0.25
+            self.add_annotation(a.x, a.y, a.label, a.color)
+
+    def plot_branches(self) -> None:
+        """
+        Plot the branches.
+
+        This is separated from `draw_tree` so it can be used in callbacks when
+        the track colours are changed, but the track_id is not.
+        """
+        for e in self.edges:
+            if e.id is not None:
+                color = self.tracks.track_colors[
+                    np.where(self.tracks.properties["track_id"] == e.id)
+                ]
+                # For a track that has colour varying along it, just select the
+                # first colour for now
+                color = color[-1, :]
+            else:
+                color = e.color
+            self.add_branch(e.x, e.y, color)
+
+    @abc.abstractmethod
+    def add_branch(
+        self, x: Sequence[float], y: Sequence[float], color: ColorType
+    ) -> None:
+        """
+        Add a single branch to the tree.
+
+        Parameters
+        ----------
+        x, y : Sequence[float]
+            x/y coordinates of the branch.
+        color : ColorType
+            Color in a RGBA tuple with values in the range [0, 1].
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_annotation(self, x: float, y: float, label: str, color: ColorType) -> None:
+        """
+        Add a single label to the tree.
+
+        Parameters
+        ----------
+        x, y : float
+            x/y coordinate of the annotation.
+        label : str
+            Annotation text.
+        color : ColorType
+            Color in a RGBA tuple with values in the range [0, 1].
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def set_title(self, title: str) -> None:
+        """
+        Set the title of the plot.
+
+        Parameters
+        ----------
+        title : str
+            Plot title.
+        """
+        raise NotImplementedError()
+
+
+class TreePlotterQWidgetBase(TreePlotterBase):
+    """
+    Base class for a tree plotter that provides a QWidget
+    (e.g. for embedding in a napari plugin).
+    """
+
+    @abc.abstractmethod
+    def get_qwidget(self) -> QWidget:
+        """
+        Return the native QWidget for embedding.
+        """
+        raise NotImplementedError()

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -34,7 +34,7 @@ class TreePlotterBase(abc.ABC):
         return self._tracks
 
     @tracks.setter
-    def tracks(self, track_layer: napari.layers.Tracks):
+    def tracks(self, track_layer: napari.layers.Tracks) -> None:
         self._tracks = track_layer
 
     def draw_tree(self, track_id: int) -> None:

--- a/napari_arboretum/visualisation/pyqtgraph_plotter.py
+++ b/napari_arboretum/visualisation/pyqtgraph_plotter.py
@@ -1,8 +1,7 @@
-from typing import Sequence
-
 import pyqtgraph as pg
 from qtpy.QtWidgets import QWidget
 
+from ..tree import Annotation, Edge
 from .base_plotter import TreePlotterQWidgetBase
 
 __all__ = ["PyQtGraphPlotter"]
@@ -31,22 +30,22 @@ class PyQtGraphPlotter(TreePlotterQWidgetBase):
     def get_qwidget(self) -> QWidget:
         return self.plot_widget
 
-    def add_branch(self, x: Sequence[float], y: Sequence[float], color) -> None:
+    def add_branch(self, e: Edge) -> None:
         """
         Add a single branch to the tree.
         """
         # napari uses [0, 1] RGBA, pygraphqt uses [0, 255] RGBA
-        color = color * 255
-        self.plot_view.plot(y, x, pen=pg.mkPen(color=color, width=3))
+        color = e.color * 255
+        self.plot_view.plot(e.y, e.x, pen=pg.mkPen(color=color, width=3))
 
-    def add_annotation(self, x: float, y: float, label: str, color) -> None:
+    def add_annotation(self, a: Annotation) -> None:
         """
         Add a single label to the tree.
         """
         # napari uses [0, 1] RGBA, pygraphqt uses [0, 255] RGBA
-        color = color * 255
+        color = a.color * 255
         pt = pg.TextItem(
-            text=label,
+            text=a.label,
             color=color,
             html=None,
             anchor=(0, 0),
@@ -55,7 +54,7 @@ class PyQtGraphPlotter(TreePlotterQWidgetBase):
             angle=0,
             rotateAxis=None,
         )
-        pt.setPos(y, x)
+        pt.setPos(a.y, a.x)
         self.plot_view.addItem(pt, ignoreBounds=True)
 
     def set_title(self, title: str) -> None:

--- a/napari_arboretum/visualisation/pyqtgraph_plotter.py
+++ b/napari_arboretum/visualisation/pyqtgraph_plotter.py
@@ -1,0 +1,76 @@
+from typing import Sequence
+
+import pyqtgraph as pg
+from qtpy.QtWidgets import QWidget
+
+from .base_plotter import TreePlotterQWidgetBase
+
+__all__ = ["PyQtGraphPlotter"]
+
+
+class PyQtGraphPlotter(TreePlotterQWidgetBase):
+    """
+    Tree plotter using pyqtgraph as the plotting backend.
+
+    Attributes
+    ----------
+    plot_widget : pyqtgraph.GraphicsLayoutWidget
+        Main plotting widget.
+    """
+
+    def __init__(self):
+        """
+        Setup the plot view.
+        """
+        self.plot_widget = pg.GraphicsLayoutWidget()
+        self.plot_view = self.plot_widget.addPlot(
+            title="Lineage tree", labels={"left": "Time"}
+        )
+        self.plot_view.hideAxis("bottom")
+
+    def get_qwidget(self) -> QWidget:
+        return self.plot_widget
+
+    def add_branch(self, x: Sequence[float], y: Sequence[float], color) -> None:
+        """
+        Add a single branch to the tree.
+        """
+        # napari uses [0, 1] RGBA, pygraphqt uses [0, 255] RGBA
+        color = color * 255
+        self.plot_view.plot(y, x, pen=pg.mkPen(color=color, width=3))
+
+    def add_annotation(self, x: float, y: float, label: str, color) -> None:
+        """
+        Add a single label to the tree.
+        """
+        # napari uses [0, 1] RGBA, pygraphqt uses [0, 255] RGBA
+        color = color * 255
+        pt = pg.TextItem(
+            text=label,
+            color=color,
+            html=None,
+            anchor=(0, 0),
+            border=None,
+            fill=None,
+            angle=0,
+            rotateAxis=None,
+        )
+        pt.setPos(y, x)
+        self.plot_view.addItem(pt, ignoreBounds=True)
+
+    def set_title(self, title: str) -> None:
+        """
+        Set the title of the plot.
+        """
+        self.plot_view.setTitle(title)
+
+    def draw_tree(self, track_id: int) -> None:
+        """
+        Plot graph on the plugin canvas.
+        """
+        self.plot_view.clear()
+        # NOTE(arl): disabling the autoranging improves perfomance dramatically
+        # https://stackoverflow.com/questions/17103698/plotting-large-arrays-in-pyqtgraph
+        self.plot_view.disableAutoRange()
+        super().draw_tree(track_id)
+        self.plot_view.autoRange()


### PR DESCRIPTION
This is a relatively large refactor to:

- Create a `TreePlotterBase` class, which contains the functionality needed to translate between a `napari.layers.Tracks` layer and visual objects (e.g. lines, text). This could in theory be used independently of `napari-arboretum` to create other visualisations of tracks (e.g. one could quite easily implement a `MatplotlibTreePlotter`).
- Create a `PyQtGraphPlotter`, a concrete implementation of `TreePlotterBase` to plot tracks in the `napari` plugin window.

Decoupling the tracks -> plot objects -> rendering steps makes it super easy to switch the backend from `pyqtgraph` to `vispy`, and potentially change the plotting backend (or just implement more backends) in the future.

All functionality should remain the same with this PR. Since I've created quite a lot new API here, I'd appreciate it if reviewers paid particular attention to the API and whether it makes any sense.