### PR TITLE
Clean up some of the tree/graph code

### DIFF
--- a/napari_arboretum/_tests/test_graph.py
+++ b/napari_arboretum/_tests/test_graph.py
@@ -40,15 +40,15 @@ def test_build_subgraph():
 def test_node_is_root():
     """Test the `TreeNode` class."""
     node = graph.TreeNode(generation=1, ID=1, t=(1, 2))
-    assert node.is_root()
+    assert node.is_root
 
     node = graph.TreeNode(generation=2, ID=1, t=(1, 2))
-    assert not node.is_root()
+    assert not node.is_root
 
 
 def test_node_is_leaf():
     """Test the `TreeNode` class."""
     node2 = graph.TreeNode(generation=2, ID=2, t=(2, 3))
     node1 = graph.TreeNode(generation=1, ID=1, t=(1, 2), children=[node2])
-    assert not node1.is_leaf()
-    assert node2.is_leaf()
+    assert not node1.is_leaf
+    assert node2.is_leaf

--- a/napari_arboretum/graph.py
+++ b/napari_arboretum/graph.py
@@ -20,9 +20,11 @@ class TreeNode:
     generation: int
     children: List[int] = field(default_factory=list)
 
+    @property
     def is_root(self) -> bool:
         return self.generation == 1
 
+    @property
     def is_leaf(self) -> bool:
         return not self.children
 

--- a/napari_arboretum/graph.py
+++ b/napari_arboretum/graph.py
@@ -18,7 +18,7 @@ class TreeNode:
     ID: int
     t: Tuple[int, int]
     generation: int
-    children: List["TreeNode"] = field(default_factory=list)
+    children: List[int] = field(default_factory=list)
 
     def is_root(self) -> bool:
         return self.generation == 1

--- a/napari_arboretum/graph.py
+++ b/napari_arboretum/graph.py
@@ -1,21 +1,14 @@
-# ------------------------------------------------------------------------------
-# Name:     Arboretum
-# Purpose:  Dockable widget, and custom track visualization layers for Napari,
-#           to cell/object track data.
-#
-# Authors:  Alan R. Lowe (arl) a.lowe@ucl.ac.uk
-#
-# License:  See LICENSE.md
-#
-# Created:  01/05/2020
-# ------------------------------------------------------------------------------
+"""
+Classes and functions for working with graphs.
+
+Note that this file should *not* contain code for laying out the graphs for
+visualisation. Code for this is kept in `tree.py`.
+"""
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import napari
 import numpy as np
-
-from .tree import _build_tree
 
 
 @dataclass
@@ -163,7 +156,3 @@ def build_subgraph(
                 nodes.append(child_node)
 
     return root_id, nodes
-
-
-def layout_subgraph(root_id, subgraph_nodes):
-    return _build_tree(subgraph_nodes)

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -48,7 +48,7 @@ class Arboretum(QWidget):
                 # Add callback to draw graph when layer clicked
                 self.append_mouse_callback(layer)
                 # Add callback to change tree colours when layer colours changed
-                layer.events.color_by.connect(self.plotter.update_egde_colors)
+                layer.events.color_by.connect(self.plotter.update_edge_colors)
 
         self.tracks_layers = layers
 

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -1,17 +1,19 @@
+"""
+Classes and functions for laying out graphs for visualisation.
+"""
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import numpy as np
-from napari.utils.colormaps import AVAILABLE_COLORMAPS
+
+from .graph import TreeNode
 
 # colormaps
-turbo = AVAILABLE_COLORMAPS["turbo"]
-WHITE = np.array([1, 1, 1, 1], dtype=float)
-RED = np.array([1, 0, 0, 1], dtype=float)
+WHITE = [1.0, 1.0, 1.0, 1.0]
 
 # napari specifies colours as a RGBA tuple in the range [0, 1], so mirror
 # that convention throughout arboretum.
-ColorType = Tuple[float, float, float, float]
+ColorType = List[float]
 
 
 @dataclass
@@ -30,20 +32,19 @@ class Edge:
     id: Optional[int] = None
 
 
-def _build_tree(nodes) -> Tuple[List[Edge], List[Annotation]]:
+def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
     """Build and layout the edges of a lineage tree, given the graph nodes.
 
     Parameters
     ----------
-    nodes : list
+    nodes :
         A list of graph.TreeNode objects encoding a single lineage tree.
 
     Returns
     -------
-    edges : list
+    edges :
         A list of edges to be drawn.
-
-    annotations : list
+    annotations :
         A list of annotations to be added to the graph.
     """
     # put the start vertex into the queue, and the marked list
@@ -51,7 +52,7 @@ def _build_tree(nodes) -> Tuple[List[Edge], List[Annotation]]:
 
     queue = [root]
     marked = [root]
-    y_pos = [0]
+    y_pos = [0.0]
 
     # store the line coordinates that need to be plotted
     edges = []

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -2,18 +2,18 @@
 Classes and functions for laying out graphs for visualisation.
 """
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, MutableSequence, Optional, Tuple
 
 import numpy as np
 
 from .graph import TreeNode
 
 # colormaps
-WHITE = [1.0, 1.0, 1.0, 1.0]
+WHITE = np.array([1.0, 1.0, 1.0, 1.0])
 
 # napari specifies colours as a RGBA tuple in the range [0, 1], so mirror
 # that convention throughout arboretum.
-ColorType = List[float]
+ColorType = MutableSequence[float]
 
 
 @dataclass

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -3,8 +3,8 @@ import abc
 import napari
 from qtpy.QtWidgets import QWidget
 
-from ..graph import build_subgraph, layout_subgraph
-from ..tree import Annotation, Edge
+from ..graph import build_subgraph
+from ..tree import Annotation, Edge, layout_tree
 
 GUI_MAXIMUM_WIDTH = 600
 
@@ -47,7 +47,7 @@ class TreePlotterBase(abc.ABC):
         """
         self.clear()
         root, subgraph_nodes = build_subgraph(self.tracks, track_id)
-        self.edges, self.annotations = layout_subgraph(root, subgraph_nodes)
+        self.edges, self.annotations = layout_tree(subgraph_nodes)
 
         self.update_egde_colors(update_live=False)
         for e in self.edges:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List
+from typing import List, Optional
 
 import napari
 from qtpy.QtWidgets import QWidget
@@ -54,7 +54,9 @@ class TreePlotterBase(abc.ABC):
         root, subgraph_nodes = build_subgraph(self.tracks, track_id)
         self.draw_from_nodes(subgraph_nodes, track_id)
 
-    def draw_from_nodes(self, tree_nodes: List[TreeNode], track_id=None):
+    def draw_from_nodes(
+        self, tree_nodes: List[TreeNode], track_id: Optional[int] = None
+    ):
         self.edges, self.annotations = layout_tree(tree_nodes)
 
         if self.has_tracks:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -60,7 +60,7 @@ class TreePlotterBase(abc.ABC):
         self.edges, self.annotations = layout_tree(tree_nodes)
 
         if self.has_tracks:
-            self.update_egde_colors(update_live=False)
+            self.update_edge_colors(update_live=False)
 
         for e in self.edges:
             self.add_branch(e)
@@ -72,7 +72,7 @@ class TreePlotterBase(abc.ABC):
             a.color[3] = 1 if a.label == str(track_id) else 0.25
             self.add_annotation(a)
 
-    def update_egde_colors(self, update_live: bool = True) -> None:
+    def update_edge_colors(self, update_live: bool = True) -> None:
         """
         Update tree edge colours from the track properties.
 


### PR DESCRIPTION
- Move the tree layout code such that `graph.py` contains all the code for "abstract" representations of graphs, and `tree.py` contains all the code for laying out graphs for visualisation.
- Add and fix some typing
- Add missing property decorators
- Fix colour typing. I think the best thing to do here is specify as a `MutableSequence`, as `Tuple`s aren't mutable (and we want colours to be mutable)
- Factor out some code into `draw_from_nodes()`, that allows `Arboretum` to draw a graph starting with `List[TreeNode]`, as opposed to a `napari.layers.Tracks` object. This is useful for testing where we don't necessarily want to create a full `Tracks` layer.