### PR TITLE
Add Python 3.10 tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,8 +22,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        # Run all supported Python versions on linux
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        platform: [ubuntu-latest]
+        # Include one windows and macos run
+        include:
+        - platform: macos-latest
+          python-version: "3.9"
+        - platform: windows-latest
+          python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,15 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{37,38,39,310}
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
-
-[gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    macos-latest: macos
-    windows-latest: windows
+    3.10: py310
 
 [testenv]
-platform =
-    macos: darwin
-    linux: linux
-    windows: win32
 passenv =
     CI
     GITHUB_ACTIONS


### PR DESCRIPTION
This adds a Python 3.10 test run to the CI. As I've done elsewhere, it also removes the platform specific stuff in `tox.ini` that is unnessesary and can lead to spurious test successes if it has typos.