### PR TITLE
Add 1D property plotter

### DIFF
--- a/napari_arboretum/_tests/test_plugin.py
+++ b/napari_arboretum/_tests/test_plugin.py
@@ -19,7 +19,7 @@ def viewer_plugin(make_napari_viewer):
     viewer.add_layer(segmentation)
 
     plugin = Arboretum(viewer)
-    plugin.plotter.tracks = tracks
+    plugin.tracks = tracks
 
     return viewer, plugin
 
@@ -30,7 +30,8 @@ def test_plugin(viewer_plugin):
     works, not that the correct graph is drawn!
     """
     viewer, plugin = viewer_plugin
-    plugin.plotter.draw_tree(track_id=140)
+    # Setting this property automatically triggers graph drawing
+    plugin.track_id = 140
 
 
 def test_colormap_change(viewer_plugin):
@@ -40,7 +41,7 @@ def test_colormap_change(viewer_plugin):
     """
     viewer, plugin = viewer_plugin
     id = 140
-    plugin.plotter.draw_tree(track_id=id)
+    plugin.track_id = id
 
     tree = plugin.plotter.tree
     old_color = tree.get_branch_color(branch_id=id)
@@ -62,7 +63,7 @@ def test_colorby_change(viewer_plugin):
     """
     viewer, plugin = viewer_plugin
     id = 140
-    plugin.plotter.draw_tree(track_id=id)
+    plugin.track_id = id
 
     tree = plugin.plotter.tree
     old_color = tree.get_branch_color(branch_id=id)

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
 import napari
+from napari.layers import Tracks
+from napari.utils.events import Event
 from napari.utils.events import Event
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QWidget
@@ -46,18 +48,40 @@ class Arboretum(QWidget):
         # Update the horizontal time line if the current z-step changes
         self.viewer.dims.events.current_step.connect(self.draw_current_time_line)
 
-        self.tracks_layers: List[napari.layers.Tracks] = []
+        self.tracks_layers: List[Tracks] = []
         self.update_tracks_layers()
 
-    def update_tracks_layers(self, event=None) -> None:
+    @property
+    def tracks(self) -> Tracks:
         """
-        Get the Tracks layers that are present in the viewer.
+        Tracks layer being plotted in the widget.
         """
-        layers = [
-            layer
-            for layer in self.viewer.layers
-            if isinstance(layer, napari.layers.Tracks)
-        ]
+        return self._tracks
+
+    @tracks.setter
+    def tracks(self, tracks: Tracks) -> None:
+        self._tracks = tracks
+        self.plotter.tracks = tracks
+        self.property_plotter.tracks = tracks
+
+    @property
+    def track_id(self) -> int:
+        """
+        ID of the specific track being plotted in the widget.
+        """
+        return self._track_id
+
+    @track_id.setter
+    def track_id(self, track_id: int) -> None:
+        self._track_id = track_id
+        self.plotter.track_id = track_id
+        self.property_plotter.track_id = track_id
+
+    def update_tracks_layers(self, event: Optional[Event] = None) -> None:
+        """
+        Save a copy of all the tracks layers that are present in the viewer.
+        """
+        layers = [layer for layer in self.viewer.layers if isinstance(layer, Tracks)]
 
         for layer in layers:
             if layer not in self.tracks_layers:
@@ -70,26 +94,22 @@ class Arboretum(QWidget):
 
         self.tracks_layers = layers
 
-    def append_mouse_callback(self, track_layer: napari.layers.Tracks) -> None:
+    def append_mouse_callback(self, track_layer: Tracks) -> None:
         """
         Add a mouse callback to ``track_layer`` to draw the tree
         when the layer is clicked.
         """
 
         @track_layer.mouse_drag_callbacks.append
-        def show_tree(layer: napari.layers.Tracks, event: Event) -> None:
-            self.plotter.tracks = layer
-            self.property_plotter.tracks = layer
+        def show_tree(tracks: Tracks, event: Event) -> None:
+            self.tracks = tracks
 
             cursor_position = event.position
-            track_id = layer.get_value(cursor_position, world=True)
-            if not track_id:
-                return
-
-            self.plotter.draw_tree(track_id)
-            self.track_id = track_id
-            self.property_plotter.track_id = track_id
-            self.property_plotter.plot_property()
+            track_id = tracks.get_value(cursor_position, world=True)
+            if track_id is not None:
+                # Setting this property automatically triggers re-drawing of the
+                # tree and property graph
+                self.track_id = track_id
 
     def draw_current_time_line(self, event: Optional[Event] = None) -> None:
         if not self.plotter.has_tracks:

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import napari
 from napari.utils.events import Event
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QVBoxLayout, QWidget
+from qtpy.QtWidgets import QGridLayout, QWidget
 
 from .visualisation import (
     MPLPropertyPlotter,
@@ -27,16 +27,18 @@ class Arboretum(QWidget):
         self.property_plotter: PropertyPlotterBase = MPLPropertyPlotter(viewer)
 
         # Set plugin layout
-        layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignTop)
-        layout.setSpacing(4)
-        self.setMaximumWidth(GUI_MAXIMUM_WIDTH)
+        layout = QGridLayout()
+        # Make the tree plot a bigger than the property plot
+        for row, stretch in zip([0, 1], [2, 1]):
+            layout.setRowStretch(row, stretch)
         self.setLayout(layout)
 
         # Add tree plotter
-        layout.addWidget(self.plotter.get_qwidget())
+        row, col = 0, 0
+        layout.addWidget(self.plotter.get_qwidget(), row, col)
         # Add property plotter
-        layout.addWidget(self.property_plotter.get_qwidget())
+        row = 1
+        layout.addWidget(self.property_plotter.get_qwidget(), row, col)
 
         # Update the list of tracks layers stored in this object if the layer
         # list changes

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -77,7 +77,7 @@ class Arboretum(QWidget):
         """
 
         @track_layer.mouse_drag_callbacks.append
-        def show_tree(layer, event):
+        def show_tree(layer: napari.layers.Tracks, event: Event) -> None:
             self.plotter.tracks = layer
             self.property_plotter.tracks = layer
 

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -1,8 +1,6 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import napari
-import numpy as np
-import pandas as pd
 from napari.utils.events import Event
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QWidget
@@ -66,6 +64,7 @@ class Arboretum(QWidget):
                 # Add callback to change tree colours when layer colours changed
                 layer.events.color_by.connect(self.plotter.update_edge_colors)
                 layer.events.colormap.connect(self.plotter.update_edge_colors)
+                layer.events.color_by.connect(self.property_plotter.plot_property)
 
         self.tracks_layers = layers
 
@@ -87,18 +86,11 @@ class Arboretum(QWidget):
 
             self.plotter.draw_tree(track_id)
             self.track_id = track_id
-            self.property_plotter.plot_property(track_id)
+            self.property_plotter.track_id = track_id
+            self.property_plotter.plot_property()
 
     def draw_current_time_line(self, event: Optional[Event] = None) -> None:
         if not self.plotter.has_tracks:
             return
         z_value = self.viewer.dims.current_step[0]
         self.plotter.draw_current_time_line(z_value)
-
-
-def get_property(
-    layer: napari.layers.Tracks, track_id: int
-) -> Tuple[np.ndarray, np.ndarray]:
-    all_props = pd.DataFrame(layer.properties)
-    all_props = all_props.loc[all_props["track_id"] == track_id]
-    return all_props["t"].values, all_props[layer.color_by].values

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -1,11 +1,8 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import napari
 import numpy as np
 import pandas as pd
-from typing import List, Optional
-
-import napari
 from napari.utils.events import Event
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QWidget
@@ -90,12 +87,7 @@ class Arboretum(QWidget):
 
             self.plotter.draw_tree(track_id)
             self.track_id = track_id
-
-            t, prop = get_property(layer, track_id)
-            self.property_plotter.plot(t, prop)
-            self.property_plotter.set_xlabel("Time")
-            self.property_plotter.set_ylabel(layer.color_by)
-            self.draw_current_time_line()
+            self.property_plotter.plot_property(track_id)
 
     def draw_current_time_line(self, event: Optional[Event] = None) -> None:
         if not self.plotter.has_tracks:

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -3,8 +3,6 @@ from typing import List, Optional
 import napari
 from napari.layers import Tracks
 from napari.utils.events import Event
-from napari.utils.events import Event
-from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QWidget
 
 from .util import TrackPropertyMixin

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -97,3 +97,4 @@ class Arboretum(QWidget, TrackPropertyMixin):
             return
         z_value = self.viewer.dims.current_step[0]
         self.plotter.draw_current_time_line(z_value)
+        self.property_plotter.draw_current_time_line(z_value)

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -7,6 +7,7 @@ from napari.utils.events import Event
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QWidget
 
+from .util import TrackPropertyMixin
 from .visualisation import (
     MPLPropertyPlotter,
     PropertyPlotterBase,
@@ -17,7 +18,7 @@ from .visualisation import (
 GUI_MAXIMUM_WIDTH = 400
 
 
-class Arboretum(QWidget):
+class Arboretum(QWidget, TrackPropertyMixin):
     """
     Tree viewer widget.
     """
@@ -51,31 +52,13 @@ class Arboretum(QWidget):
         self.tracks_layers: List[Tracks] = []
         self.update_tracks_layers()
 
-    @property
-    def tracks(self) -> Tracks:
-        """
-        Tracks layer being plotted in the widget.
-        """
-        return self._tracks
+    def on_tracks_change(self):
+        self.plotter.tracks = self.tracks
+        self.property_plotter.tracks = self.tracks
 
-    @tracks.setter
-    def tracks(self, tracks: Tracks) -> None:
-        self._tracks = tracks
-        self.plotter.tracks = tracks
-        self.property_plotter.tracks = tracks
-
-    @property
-    def track_id(self) -> int:
-        """
-        ID of the specific track being plotted in the widget.
-        """
-        return self._track_id
-
-    @track_id.setter
-    def track_id(self, track_id: int) -> None:
-        self._track_id = track_id
-        self.plotter.track_id = track_id
-        self.property_plotter.track_id = track_id
+    def on_track_id_change(self):
+        self.plotter.track_id = self.track_id
+        self.property_plotter.track_id = self.track_id
 
     def update_tracks_layers(self, event: Optional[Event] = None) -> None:
         """

--- a/napari_arboretum/util.py
+++ b/napari_arboretum/util.py
@@ -1,0 +1,47 @@
+from napari.layers import Tracks
+
+
+class TrackPropertyMixin:
+    """
+    Mixin class to add ``.tracks`` and ``.track_id`` properties.
+    """
+
+    @property
+    def tracks(self) -> Tracks:
+        """
+        napari tracks layer.
+        """
+        if not hasattr(self, "_tracks"):
+            raise AttributeError("No tracks set on this plotter.")
+        return self._tracks
+
+    @tracks.setter
+    def tracks(self, tracks: Tracks) -> None:
+        self._tracks = tracks
+        self.on_tracks_change()
+
+    @property
+    def track_id(self) -> int:
+        """
+        napari track ID.
+        """
+        if not hasattr(self, "_track_id"):
+            raise AttributeError("No track ID set on this plotter.")
+        return self._track_id
+
+    @track_id.setter
+    def track_id(self, track_id: int) -> None:
+        self._track_id = track_id
+        self.on_track_id_change()
+
+    def on_tracks_change(self) -> None:
+        """
+        Optional method that derived classes can override to do something
+        when the tracks layer changes.
+        """
+
+    def on_track_id_change(self) -> None:
+        """
+        Optional method that derived classes can override to do something
+        when the track ID is changed.
+        """

--- a/napari_arboretum/visualisation/__init__.py
+++ b/napari_arboretum/visualisation/__init__.py
@@ -11,4 +11,5 @@ that must be implemented.
 """
 
 from .base_plotter import *
+from .matplotlib_plotter import *
 from .vispy_plotter import *

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -45,16 +45,28 @@ class TreePlotterBase(abc.ABC):
         self._tracks = track_layer
 
     @property
+    def track_id(self) -> int:
+        """
+        Track ID of the currently selected track.
+        """
+        return self._track_id
+
+    @track_id.setter
+    def track_id(self, track_id: int) -> None:
+        self._track_id = track_id
+        self.draw_tree()
+
+    @property
     def has_tracks(self) -> bool:
         return hasattr(self, "_tracks")
 
-    def draw_tree(self, track_id: int) -> None:
+    def draw_tree(self) -> None:
         """
-        Plot the tree containing ``track_id``.
+        Plot the tree.
         """
         self.clear()
-        root, subgraph_nodes = build_subgraph(self.tracks, track_id)
-        self.draw_from_nodes(subgraph_nodes, track_id)
+        root, subgraph_nodes = build_subgraph(self.tracks, self.track_id)
+        self.draw_from_nodes(subgraph_nodes, self.track_id)
 
     def draw_from_nodes(
         self, tree_nodes: List[TreeNode], track_id: Optional[int] = None
@@ -150,9 +162,28 @@ class PropertyPlotterBase(abc.ABC):
     Base class for plotting a 1D graph of track property against time.
     """
 
-    def __init__(self):
-        self.tracks = None
-        self.track_id = None
+    @property
+    def tracks(self) -> napari.layers.Tracks:
+        """
+        The napari tracks layer associated with this plotter.
+        """
+        return self._tracks
+
+    @tracks.setter
+    def tracks(self, track_layer: napari.layers.Tracks) -> None:
+        self._tracks = track_layer
+
+    @property
+    def track_id(self) -> int:
+        """
+        Track ID of the currently selected track.
+        """
+        return self._track_id
+
+    @track_id.setter
+    def track_id(self, track_id: int) -> None:
+        self._track_id = track_id
+        self.plot_property()
 
     def plot_property(self) -> None:
         """

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -150,33 +150,22 @@ class PropertyPlotterBase(abc.ABC):
     Base class for plotting a 1D graph of track property against time.
     """
 
-    @property
-    def tracks(self) -> napari.layers.Tracks:
+    def __init__(self):
+        self.tracks = None
+        self.track_id = None
+
+    def plot_property(self) -> None:
         """
-        The napari tracks layer associated with this plotter.
+        Plot a property. The property is taken from the currently selected
+        layer, currently selected track_id, and the property used to 'color_by'
+        in the napari viewer.
         """
-        if not self.has_tracks:
-            raise AttributeError("No tracks set on this plotter.")
-        return self._tracks
-
-    @tracks.setter
-    def tracks(self, track_layer: napari.layers.Tracks) -> None:
-        self._tracks = track_layer
-
-    @property
-    def has_tracks(self) -> bool:
-        return hasattr(self, "_tracks")
-
-    def plot_property(self, track_id: int) -> None:
-        t, prop = self.get_track_property(self.tracks, track_id)
+        t, prop = self.get_track_properties()
         self.plot(t, prop)
         self.set_xlabel("Time")
         self.set_ylabel(self.tracks.color_by)
 
-    @staticmethod
-    def get_track_property(
-        layer: napari.layers.Tracks, track_id: int
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    def get_track_properties(self) -> Tuple[np.ndarray, np.ndarray]:
         """
         For a given layer and track_id, get time values and property that
         the track is currently coloured by.
@@ -188,9 +177,9 @@ class PropertyPlotterBase(abc.ABC):
         prop :
             Property values.
         """
-        all_props = pd.DataFrame(layer.properties)
-        all_props = all_props.loc[all_props["track_id"] == track_id]
-        return all_props["t"].values, all_props[layer.color_by].values
+        all_props = pd.DataFrame(self.tracks.properties)
+        all_props = all_props.loc[all_props["track_id"] == self.track_id]
+        return all_props["t"].values, all_props[self.tracks.color_by].values
 
     @abc.abstractmethod
     def get_qwidget(self) -> QWidget:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -163,8 +163,10 @@ class PropertyPlotterBase(abc.ABC):
         t, prop = self.get_track_properties()
         self.plot(t, prop)
         self.set_xlabel("Time")
-        self.set_ylabel(self.tracks.color_by)
+        self.set_ylabel("Property value")
+        self.set_title(self.tracks.color_by)
         self.draw_track_id(self.track_id)
+        self.redraw()
 
     def get_track_properties(self) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -207,8 +209,20 @@ class PropertyPlotterBase(abc.ABC):
         """
 
     @abc.abstractmethod
+    def set_title(self, title: str) -> None:
+        """
+        Set plot title.
+        """
+
+    @abc.abstractmethod
     def draw_track_id(self, track_id: int) -> None:
         """
         Draw track ID. Where this is drawn is up to the implmenation, and could
         e.g. be the plot title or plot legend.
+        """
+
+    def redraw(self) -> None:
+        """
+        Optional method that can be implemented by sub-classes to re-draw
+        a figure after the plot and labels have been set.
         """

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -2,6 +2,7 @@ import abc
 from typing import List, Optional
 
 import napari
+import numpy as np
 from qtpy.QtWidgets import QWidget
 
 from ..graph import TreeNode, build_subgraph
@@ -141,3 +142,32 @@ class TreePlotterQWidgetBase(TreePlotterBase):
         Return the native QWidget for embedding.
         """
         raise NotImplementedError()
+
+
+class PropertyPlotterBase(abc.ABC):
+    """
+    Base class for plotting a 1D graph of track property against time.
+    """
+
+    @abc.abstractmethod
+    def get_qwidget(self) -> QWidget:
+        """
+        Return the native QWidget for embedding.
+        """
+
+    @abc.abstractmethod
+    def plot(self, x: np.ndarray, y: np.ndarray) -> None:
+        """
+        Plot x, y values.
+        """
+
+    @abc.abstractmethod
+    def set_xlabel(self, label: str) -> None:
+        """
+        Set x-label.
+        """
+
+    def set_ylabel(self, label: str) -> None:
+        """
+        Set y-label.
+        """

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -186,6 +186,12 @@ class PropertyPlotterBase(abc.ABC, TrackPropertyMixin):
         """
 
     @abc.abstractmethod
+    def draw_current_time_line(self, time: int) -> None:
+        """
+        Indicate the current time (ie. napari viewer z-step) on the plot.
+        """
+
+    @abc.abstractmethod
     def set_xlabel(self, label: str) -> None:
         """
         Set x-label.

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -1,20 +1,20 @@
 import abc
 from typing import List, Optional, Tuple
 
-import napari
 import numpy as np
 import pandas as pd
 from qtpy.QtWidgets import QWidget
 
 from ..graph import TreeNode, build_subgraph
 from ..tree import Annotation, Edge, layout_tree
+from ..util import TrackPropertyMixin
 
 GUI_MAXIMUM_WIDTH = 600
 
 __all__ = ["TreePlotterBase", "TreePlotterQWidgetBase"]
 
 
-class TreePlotterBase(abc.ABC):
+class TreePlotterBase(abc.ABC, TrackPropertyMixin):
     """
     Base class for a `napari.layers.Tracks` plotter.
 
@@ -31,29 +31,7 @@ class TreePlotterBase(abc.ABC):
     annotations : List[Annotation]
     """
 
-    @property
-    def tracks(self) -> napari.layers.Tracks:
-        """
-        The napari tracks layer associated with this plotter.
-        """
-        if not self.has_tracks:
-            raise AttributeError("No tracks set on this plotter.")
-        return self._tracks
-
-    @tracks.setter
-    def tracks(self, track_layer: napari.layers.Tracks) -> None:
-        self._tracks = track_layer
-
-    @property
-    def track_id(self) -> int:
-        """
-        Track ID of the currently selected track.
-        """
-        return self._track_id
-
-    @track_id.setter
-    def track_id(self, track_id: int) -> None:
-        self._track_id = track_id
+    def on_track_id_change(self) -> None:
         self.draw_tree()
 
     @property
@@ -157,32 +135,12 @@ class TreePlotterQWidgetBase(TreePlotterBase):
         raise NotImplementedError()
 
 
-class PropertyPlotterBase(abc.ABC):
+class PropertyPlotterBase(abc.ABC, TrackPropertyMixin):
     """
     Base class for plotting a 1D graph of track property against time.
     """
 
-    @property
-    def tracks(self) -> napari.layers.Tracks:
-        """
-        The napari tracks layer associated with this plotter.
-        """
-        return self._tracks
-
-    @tracks.setter
-    def tracks(self, track_layer: napari.layers.Tracks) -> None:
-        self._tracks = track_layer
-
-    @property
-    def track_id(self) -> int:
-        """
-        Track ID of the currently selected track.
-        """
-        return self._track_id
-
-    @track_id.setter
-    def track_id(self, track_id: int) -> None:
-        self._track_id = track_id
+    def on_track_id_change(self) -> None:
         self.plot_property()
 
     def plot_property(self) -> None:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -164,6 +164,7 @@ class PropertyPlotterBase(abc.ABC):
         self.plot(t, prop)
         self.set_xlabel("Time")
         self.set_ylabel(self.tracks.color_by)
+        self.draw_track_id(self.track_id)
 
     def get_track_properties(self) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -203,4 +204,11 @@ class PropertyPlotterBase(abc.ABC):
     def set_ylabel(self, label: str) -> None:
         """
         Set y-label.
+        """
+
+    @abc.abstractmethod
+    def draw_track_id(self, track_id: int) -> None:
+        """
+        Draw track ID. Where this is drawn is up to the implmenation, and could
+        e.g. be the plot title or plot legend.
         """

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -16,7 +16,7 @@ class MPLPropertyPlotter(PropertyPlotterBase):
 
     def plot(self, x: np.ndarray, y: np.ndarray) -> None:
         self.axes.cla()
-        self.axes.plot(x, y)
+        self.axes.plot(x, y, label=f"id={self.track_id}")
         self.mpl_widget.canvas.draw()
 
     def set_xlabel(self, label: str) -> None:
@@ -25,4 +25,8 @@ class MPLPropertyPlotter(PropertyPlotterBase):
 
     def set_ylabel(self, label: str) -> None:
         self.axes.set_ylabel(label)
+        self.mpl_widget.canvas.draw()
+
+    def draw_track_id(self, title: int) -> None:
+        self.axes.legend()
         self.mpl_widget.canvas.draw()

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -1,0 +1,28 @@
+import numpy as np
+from napari_matplotlib.base import NapariMPLWidget
+from qtpy.QtWidgets import QWidget
+
+from .base_plotter import PropertyPlotterBase
+
+
+class MPLPropertyPlotter(PropertyPlotterBase):
+    def __init__(self, viewer):
+        self.mpl_widget = NapariMPLWidget(viewer)
+        self.figure = self.mpl_widget.canvas.figure
+        self.axes = self.mpl_widget.canvas.figure.add_subplot(111)
+
+    def get_qwidget(self) -> QWidget:
+        return self.mpl_widget
+
+    def plot(self, x: np.ndarray, y: np.ndarray) -> None:
+        self.axes.cla()
+        self.axes.plot(x, y)
+        self.mpl_widget.canvas.draw()
+
+    def set_xlabel(self, label: str) -> None:
+        self.axes.set_xlabel(label)
+        self.mpl_widget.canvas.draw()
+
+    def set_ylabel(self, label: str) -> None:
+        self.axes.set_ylabel(label)
+        self.mpl_widget.canvas.draw()

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -1,4 +1,5 @@
 import numpy as np
+from matplotlib.lines import Line2D
 from napari_matplotlib.base import NapariMPLWidget
 from qtpy.QtWidgets import QWidget
 
@@ -17,6 +18,15 @@ class MPLPropertyPlotter(PropertyPlotterBase):
     def plot(self, x: np.ndarray, y: np.ndarray) -> None:
         self.axes.cla()
         self.axes.plot(x, y, label=f"id={self.track_id}")
+
+    def draw_current_time_line(self, time: int) -> None:
+        if not hasattr(self, "_mpl_time_line"):
+            self._mpl_time_line: Line2D = self.axes.axvline(time, color="white")
+        else:
+            # TODO: fix this
+            print(time)
+            self._mpl_time_line.set_xdata([time])
+        self.mpl_widget.canvas.draw()
 
     def set_xlabel(self, label: str) -> None:
         self.axes.set_xlabel(label)

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -17,16 +17,18 @@ class MPLPropertyPlotter(PropertyPlotterBase):
     def plot(self, x: np.ndarray, y: np.ndarray) -> None:
         self.axes.cla()
         self.axes.plot(x, y, label=f"id={self.track_id}")
-        self.mpl_widget.canvas.draw()
 
     def set_xlabel(self, label: str) -> None:
         self.axes.set_xlabel(label)
-        self.mpl_widget.canvas.draw()
 
     def set_ylabel(self, label: str) -> None:
         self.axes.set_ylabel(label)
-        self.mpl_widget.canvas.draw()
+
+    def set_title(self, title: str) -> None:
+        self.axes.set_title(title)
 
     def draw_track_id(self, title: int) -> None:
         self.axes.legend()
+
+    def redraw(self) -> None:
         self.mpl_widget.canvas.draw()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 napari>=0.4.0
-napari_matplotlib
+napari-matplotlib
 numpy>=1.17.3
 pooch>=1
 pyqtgraph>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 napari>=0.4.0
-matplotlib
+napari_matplotlib
 numpy>=1.17.3
 pooch>=1
 pyqtgraph>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 napari>=0.4.0
+matplotlib
 numpy>=1.17.3
 pooch>=1
 pyqtgraph>=0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,7 @@ max-complexity = 18
 exclude =
   __init__.py
   napari_arboretum/_tests
+
+[isort]
+profile = black
+line_length = 88


### PR DESCRIPTION
This adds a way to visualse the currently selected track/property using a 1D plot made with Matplotlib. See below for a static example - the plot automatically updates when a different track ID or property is selected in napari. @KristinaUlicna perhpas you could give this a go and post any feedback you have below? There are probably a few layout/display things that could be improved, but I thought I'd open early to get some feedback.

<img width="664" alt="Screenshot 2022-05-23 at 15 07 05" src="https://user-images.githubusercontent.com/6197628/169837904-e1521d6e-c301-4349-8f3b-80a14835f591.png">
