### PR TITLE
Add title to widget indicating selected cell

### DIFF
--- a/napari_arboretum/_tests/test_graph.py
+++ b/napari_arboretum/_tests/test_graph.py
@@ -30,11 +30,21 @@ def test_build_subgraph():
     data[:, 1] = np.arange(data.shape[0])
 
     tracks = Tracks(data, graph=TEST_GRAPH)
-    root, nodes = graph.build_subgraph(tracks, TEST_GRAPH_ROOT)
+    nodes = graph.build_subgraph(tracks, TEST_GRAPH_ROOT)
     subgraph = [node.ID for node in nodes]
 
-    assert root == TEST_GRAPH_ROOT
     assert subgraph == TEST_GRAPH_LINEAR
+
+
+def test_get_root():
+    """Test getting the graph root."""
+    data = np.random.random(size=(max(TEST_GRAPH_LINEAR) + 1, 4))
+    data[:, 0] = np.arange(data.shape[0])
+    data[:, 1] = np.arange(data.shape[0])
+
+    tracks = Tracks(data, graph=TEST_GRAPH)
+    root_id = graph.get_root_id(tracks, TEST_GRAPH_ROOT)
+    assert root_id == TEST_GRAPH_ROOT
 
 
 def test_node_is_root():

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -3,7 +3,8 @@ from typing import List, Optional
 import napari
 from napari.layers import Tracks
 from napari.utils.events import Event
-from qtpy.QtWidgets import QGridLayout, QWidget
+from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QGridLayout, QLabel, QWidget
 
 from .util import TrackPropertyMixin
 from .visualisation import (
@@ -24,22 +25,28 @@ class Arboretum(QWidget, TrackPropertyMixin):
     def __init__(self, viewer: napari.Viewer, parent=None):
         super().__init__(parent=parent)
         self.viewer = viewer
+        self.title = QLabel()
         self.plotter: TreePlotterQWidgetBase = VisPyPlotter()
         self.property_plotter: PropertyPlotterBase = MPLPropertyPlotter(viewer)
 
         # Set plugin layout
         layout = QGridLayout()
-        # Make the tree plot a bigger than the property plot
-        for row, stretch in zip([0, 1], [2, 1]):
-            layout.setRowStretch(row, stretch)
-        self.setLayout(layout)
+
+        row, col = 0, 0
+        # Add title
+        layout.addWidget(self.title, row, col, Qt.AlignHCenter)
+        self.title.setText("Arboretum")
 
         # Add tree plotter
-        row, col = 0, 0
+        row = 1
         layout.addWidget(self.plotter.get_qwidget(), row, col)
         # Add property plotter
-        row = 1
+        row = 2
         layout.addWidget(self.property_plotter.get_qwidget(), row, col)
+        # Make the tree plot a bigger than the property plot
+        for row, stretch in zip([1, 2], [2, 1]):
+            layout.setRowStretch(row, stretch)
+        self.setLayout(layout)
 
         # Update the list of tracks layers stored in this object if the layer
         # list changes
@@ -55,6 +62,7 @@ class Arboretum(QWidget, TrackPropertyMixin):
         self.property_plotter.tracks = self.tracks
 
     def on_track_id_change(self):
+        self.title.setText(f"Lineage Tree #{self.track_id}")
         self.plotter.track_id = self.track_id
         self.property_plotter.track_id = self.track_id
 

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -6,6 +6,8 @@ from napari.utils.events import Event
 from PyQt5.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QLabel, QWidget
 
+from napari_arboretum.graph import get_root_id
+
 from .util import TrackPropertyMixin
 from .visualisation import (
     MPLPropertyPlotter,
@@ -62,9 +64,10 @@ class Arboretum(QWidget, TrackPropertyMixin):
         self.property_plotter.tracks = self.tracks
 
     def on_track_id_change(self):
-        self.title.setText(f"Lineage Tree #{self.track_id}")
         self.plotter.track_id = self.track_id
         self.property_plotter.track_id = self.track_id
+        root_id = get_root_id(self.tracks, self.track_id)
+        self.title.setText(f"Lineage Tree #{root_id}")
 
     def update_tracks_layers(self, event: Optional[Event] = None) -> None:
         """

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -150,7 +150,7 @@ class PropertyPlotterBase(abc.ABC, TrackPropertyMixin):
         self.plot(t, prop)
         self.set_xlabel("Time")
         self.set_ylabel("Property value")
-        self.set_title(self.tracks.color_by)
+        self.set_title(f"{self.tracks.color_by}, cell #{self.track_id}")
         self.redraw()
 
     def get_track_properties(self) -> Tuple[np.ndarray, np.ndarray]:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -59,9 +59,6 @@ class TreePlotterBase(abc.ABC, TrackPropertyMixin):
 
         # labels
         for a in self.annotations:
-            # change the alpha value according to whether this is the selected
-            # cell or another part of the tree
-            a.color[3] = 1 if a.label == str(track_id) else 0.25
             self.add_annotation(a)
 
     def update_edge_colors(self, update_live: bool = True) -> None:

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -43,7 +43,7 @@ class TreePlotterBase(abc.ABC, TrackPropertyMixin):
         Plot the tree.
         """
         self.clear()
-        root, subgraph_nodes = build_subgraph(self.tracks, self.track_id)
+        subgraph_nodes = build_subgraph(self.tracks, self.track_id)
         self.draw_from_nodes(subgraph_nodes, self.track_id)
 
     def draw_from_nodes(

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -151,7 +151,6 @@ class PropertyPlotterBase(abc.ABC, TrackPropertyMixin):
         self.set_xlabel("Time")
         self.set_ylabel("Property value")
         self.set_title(self.tracks.color_by)
-        self.draw_track_id(self.track_id)
         self.redraw()
 
     def get_track_properties(self) -> Tuple[np.ndarray, np.ndarray]:
@@ -204,13 +203,6 @@ class PropertyPlotterBase(abc.ABC, TrackPropertyMixin):
     def set_title(self, title: str) -> None:
         """
         Set plot title.
-        """
-
-    @abc.abstractmethod
-    def draw_track_id(self, track_id: int) -> None:
-        """
-        Draw track ID. Where this is drawn is up to the implmenation, and could
-        e.g. be the plot title or plot legend.
         """
 
     def redraw(self) -> None:

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -23,8 +23,6 @@ class MPLPropertyPlotter(PropertyPlotterBase):
         if not hasattr(self, "_mpl_time_line"):
             self._mpl_time_line: Line2D = self.axes.axvline(time, color="white")
         else:
-            # TODO: fix this
-            print(time)
             self._mpl_time_line.set_xdata([time])
         self.mpl_widget.canvas.draw()
 

--- a/napari_arboretum/visualisation/matplotlib_plotter.py
+++ b/napari_arboretum/visualisation/matplotlib_plotter.py
@@ -37,8 +37,5 @@ class MPLPropertyPlotter(PropertyPlotterBase):
     def set_title(self, title: str) -> None:
         self.axes.set_title(title)
 
-    def draw_track_id(self, title: int) -> None:
-        self.axes.legend()
-
     def redraw(self) -> None:
         self.mpl_widget.canvas.draw()


### PR DESCRIPTION
This adds a title of the form (e.g. for id 59) `"Lineage tree #59"`. @KristinaUlicna is this a good title? Or do you have any better suggestion for it?

I also:
- removed the legend indicating this in the 1D property plotter
- changed the tree viewer labels to all be solid white, as the title now indicates which cell is selected (fixes https://github.com/lowe-lab-ucl/arboretum/issues/47)


Fixes https://github.com/lowe-lab-ucl/arboretum/issues/61. 