### PR TITLE
Update annotation positioning and mouse events

### DIFF
--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -93,7 +93,7 @@ class Arboretum(QWidget, TrackPropertyMixin):
         when the layer is clicked.
         """
 
-        @track_layer.mouse_drag_callbacks.append
+        @track_layer.mouse_double_click_callbacks.append
         def show_tree(tracks: Tracks, event: Event) -> None:
             self.tracks = tracks
 

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -68,12 +68,13 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
         # draw the root of the tree
         edges.append(Edge(y=(y, y), x=(node.t[0], node.t[-1]), id=node.ID))
 
+        if node.is_root:
+            annotations.append(Annotation(y=y, x=node.t[0], label=str(node.ID)))
+
         # mark if this is an apoptotic tree
         if node.is_leaf:
             annotations.append(Annotation(y=y, x=node.t[-1], label=str(node.ID)))
-
-        if node.is_root:
-            annotations.append(Annotation(y=y, x=node.t[0], label=str(node.ID)))
+            continue
 
         children = [t for t in nodes if t.ID in node.children]
 
@@ -94,6 +95,11 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
 
                 # plot a linking line to the children
                 edges.append(Edge(y=(y, y_pos[-1]), x=(node.t[-1], child.t[0])))
+
+                # if it's a leaf don't plot the annotation
+                if child.is_leaf:
+                    continue
+
                 annotations.append(
                     Annotation(
                         y=y_pos[-1],

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -161,7 +161,8 @@ class TreeVisual(scene.visuals.Compound):
             pos=[y, x, 0],
             anchor_x="left",
             anchor_y="top",
-            font_size=10,
+            font_size=6,
+            rotation=90,
         )
         self.add_subvisual(visual)
         self.subvisuals.append(visual)


### PR DESCRIPTION
A couple of small improvements:
* Changed how the annotations are presented (smaller font, rotated and only one label per branch)
* Tree updates on a double click, to enable smoother movement around the canvas (Fixes #63)

![napari-arboretum](https://user-images.githubusercontent.com/8217795/175567765-6adf2bf2-ad1c-49c2-9c5f-9ea5aa0ea171.png)
