### PR TITLE
Increase rendering performance

### DIFF
--- a/examples/show_large_tree.py
+++ b/examples/show_large_tree.py
@@ -24,7 +24,7 @@ def generate_binary_tree(max_depth: int):
     return nodes
 
 
-nodes = generate_binary_tree(6)
+nodes = generate_binary_tree(8)
 print(f"{len(nodes)} total nodes")
 
 

--- a/napari_arboretum/graph.py
+++ b/napari_arboretum/graph.py
@@ -16,7 +16,7 @@ class TreeNode:
     """TreeNode."""
 
     ID: int
-    t: Tuple[int, int]
+    t: np.ndarray
     generation: int
     children: List[int] = field(default_factory=list)
 
@@ -154,7 +154,8 @@ def build_subgraph(layer: napari.layers.Tracks, search_node: int) -> List[TreeNo
     def _node_from_graph(_id):
 
         idx = np.where(layer.data[:, 0] == _id)[0]
-        t = (np.min(layer.data[idx, 1]), np.max(layer.data[idx, 1]))
+        # t = (np.min(layer.data[idx, 1]), np.max(layer.data[idx, 1]))
+        t = layer.data[idx, 1]
         node = TreeNode(ID=_id, t=t, generation=1)
 
         if _id in reverse_graph:

--- a/napari_arboretum/plugin.py
+++ b/napari_arboretum/plugin.py
@@ -93,7 +93,7 @@ class Arboretum(QWidget, TrackPropertyMixin):
         when the layer is clicked.
         """
 
-        @track_layer.mouse_drag_callbacks.append
+        @track_layer.mouse_double_click_callbacks.append
         def show_tree(tracks: Tracks, event: Event) -> None:
             self.tracks = tracks
 

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -30,6 +30,7 @@ class Edge:
     y: Tuple[float, float]
     color: np.ndarray = WHITE
     id: Optional[int] = None
+    node: Optional[TreeNode] = None
 
 
 def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
@@ -66,7 +67,7 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
         y = y_pos.pop(0)
 
         # draw the root of the tree
-        edges.append(Edge(y=(y, y), x=(node.t[0], node.t[-1]), id=node.ID))
+        edges.append(Edge(y=(y, y), x=(node.t[0], node.t[-1]), id=node.ID, node=node))
 
         if node.is_root:
             annotations.append(Annotation(y=y, x=node.t[0], label=str(node.ID)))
@@ -107,15 +108,5 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
                         label=str(child.ID),
                     )
                 )
-
-    # now that we have traversed the tree, calculate the span
-    tree_span = []
-    for edge in edges:
-        tree_span.append(edge.y[0])
-        tree_span.append(edge.y[1])
-
-    # # work out the span of the tree, we can modify positioning here
-    # min_x = min(tree_span)
-    # max_x = max(tree_span)
 
     return edges, annotations

--- a/napari_arboretum/tree.py
+++ b/napari_arboretum/tree.py
@@ -68,12 +68,13 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
         # draw the root of the tree
         edges.append(Edge(y=(y, y), x=(node.t[0], node.t[-1]), id=node.ID))
 
+        if node.is_root:
+            annotations.append(Annotation(y=y, x=node.t[0], label=str(node.ID)))
+
         # mark if this is an apoptotic tree
         if node.is_leaf:
             annotations.append(Annotation(y=y, x=node.t[-1], label=str(node.ID)))
-
-        if node.is_root:
-            annotations.append(Annotation(y=y, x=node.t[0], label=str(node.ID)))
+            continue
 
         children = [t for t in nodes if t.ID in node.children]
 
@@ -94,6 +95,11 @@ def layout_tree(nodes: List[TreeNode]) -> Tuple[List[Edge], List[Annotation]]:
 
                 # plot a linking line to the children
                 edges.append(Edge(y=(y, y_pos[-1]), x=(node.t[-1], child.t[0])))
+
+                # if it's a leaf don't plot the annotation
+                if child.is_leaf:
+                    continue
+
                 annotations.append(
                     Annotation(
                         y=y_pos[-1],

--- a/napari_arboretum/visualisation/base_plotter.py
+++ b/napari_arboretum/visualisation/base_plotter.py
@@ -9,6 +9,8 @@ from ..graph import TreeNode, build_subgraph
 from ..tree import Annotation, Edge, layout_tree
 from ..util import TrackPropertyMixin
 
+# from ..profiler import profiler
+
 GUI_MAXIMUM_WIDTH = 600
 
 __all__ = ["TreePlotterBase", "TreePlotterQWidgetBase"]
@@ -46,6 +48,7 @@ class TreePlotterBase(abc.ABC, TrackPropertyMixin):
         subgraph_nodes = build_subgraph(self.tracks, self.track_id)
         self.draw_from_nodes(subgraph_nodes, self.track_id)
 
+    # @profiler("draw_from_nodes")
     def draw_from_nodes(
         self, tree_nodes: List[TreeNode], track_id: Optional[int] = None
     ):
@@ -60,6 +63,8 @@ class TreePlotterBase(abc.ABC, TrackPropertyMixin):
         # labels
         for a in self.annotations:
             self.add_annotation(a)
+
+        self.draw_tree_visual()
 
     def update_edge_colors(self, update_live: bool = True) -> None:
         """
@@ -114,6 +119,13 @@ class TreePlotterBase(abc.ABC, TrackPropertyMixin):
     def draw_current_time_line(self, time: int) -> None:
         """
         Draw a horizontal line at the current timestep to the tree.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def draw_tree_visual(self) -> None:
+        """
+        Function to draw the visual after construction.
         """
         raise NotImplementedError
 

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -19,6 +19,32 @@ class Bounds:
     ymax: float
 
 
+@dataclass
+class TrackSubvisualProxy:
+    pos: np.ndarray
+    width: int = 3
+    color: np.ndarray = np.array([1.0, 1.0, 1.0, 1.0])
+
+    @property
+    def connex(self):
+        connex = [True] * (self.pos.shape[0] - 1) + [False]
+        return connex
+
+    @property
+    def safe_color(self) -> np.ndarray:
+        if self.color.ndim != 2:
+            safe_color = np.repeat([self.color], self.pos.shape[0], axis=0)
+            return safe_color
+        return self.color
+
+
+@dataclass
+class AnnotationSubvisualProxy:
+    pos: np.ndarray
+    text: str
+    color: str = "white"
+
+
 class VisPyPlotter(TreePlotterQWidgetBase):
     """
     Tree plotter using pyqtgraph as the plotting backend.
@@ -38,7 +64,7 @@ class VisPyPlotter(TreePlotterQWidgetBase):
         self.canvas = scene.SceneCanvas(keys=None, size=(300, 1200))
         self.view = self.canvas.central_widget.add_view()
         self.view.camera = scene.PanZoomCamera()
-        self.tree = TreeVisual(parent=None)
+        self.tree = TreeVisualFast(parent=None)
         self.view.add(self.tree)
 
     def get_qwidget(self) -> QWidget:
@@ -104,6 +130,12 @@ class VisPyPlotter(TreePlotterQWidgetBase):
             pos=np.array([[bounds.xmin - padding, time], [bounds.xmax + padding, time]])
         )
 
+    def draw_tree_visual(self) -> None:
+        """
+        Draw the whole tree.
+        """
+        self.tree.draw_tree()
+
 
 class TreeVisual(scene.visuals.Compound):
     """
@@ -139,6 +171,7 @@ class TreeVisual(scene.visuals.Compound):
             Array of shape (n, 4) specifying RGBA values in range [0, 1] along
             the track.
         """
+
         if id is None:
             visual = scene.visuals.Line(pos=pos, color=color, width=3)
         else:
@@ -171,3 +204,114 @@ class TreeVisual(scene.visuals.Compound):
         while self.subvisuals:
             subvisual = self.subvisuals.pop()
             self.remove_subvisual(subvisual)
+
+    def draw_tree(self) -> None:
+        pass
+
+
+class TreeVisualFast(scene.visuals.Compound):
+    """
+    Tree visual that stores branches as sub-visuals.
+    """
+
+    def __init__(self, parent):
+        super().__init__([])
+        self.parent = parent
+        self.unfreeze()
+        # Keep a reference to tracks we add so their colour can be changed later
+        self.tracks = {}
+        self.edges = []
+        self.annotations = []
+
+        subvisuals = [
+            scene.visuals.Line(color="white", width=3),
+            scene.visuals.Text(
+                anchor_x="left",
+                anchor_y="top",
+                rotation=90,
+                font_size=8,
+                color="white",
+            ),
+        ]
+
+        for visual in subvisuals:
+            self.add_subvisual(visual)
+
+    def get_branch_color(self, branch_id: int) -> np.ndarray:
+        return self.tracks[branch_id].color
+
+    def set_branch_color(self, branch_id: int, color: np.ndarray) -> None:
+        """
+        Set the color of an individual branch.
+        """
+        self.tracks[branch_id].color = color
+        self._subvisuals[0].set_data(
+            color=np.row_stack([e.safe_color for e in self.edges]),
+        )
+
+    def add_track(self, id: Optional[int], pos: np.ndarray, color: np.ndarray) -> None:
+        """
+        Parameters
+        ----------
+        id :
+            Track ID.
+        pos :
+            Array of shape (2, 2) specifying vertex coordinates.
+        color :
+            Array of shape (n, 4) specifying RGBA values in range [0, 1] along
+            the track.
+        """
+
+        if id is None:
+            subvisual_proxy = TrackSubvisualProxy(
+                pos=pos,
+                color=np.array([1.0, 1.0, 1.0, 1.0]),
+                width=3,
+            )
+        else:
+            # Split up line into individual time steps so color can vary
+            # along the line
+            ys = np.arange(pos[0, 1], pos[1, 1] + 1)
+            xs = np.ones(ys.size) * pos[0, 0]
+            subvisual_proxy = TrackSubvisualProxy(
+                pos=np.column_stack((xs, ys)),
+                color=color,
+            )
+            # store a reference to this subvisual proxy
+            self.tracks[id] = subvisual_proxy
+
+        self.edges.append(subvisual_proxy)
+
+    def add_annotation(self, x: float, y: float, label: str, color):
+
+        subvisual_proxy = AnnotationSubvisualProxy(
+            text=label,
+            pos=[y, x, 0],
+        )
+
+        self.annotations.append(subvisual_proxy)
+
+    def clear(self) -> None:
+        """Remove all tracks."""
+        self.tracks = {}
+        self.edges = []
+        self.annotations = []
+
+        for visual in self._subvisuals:
+            visual._pos = None
+
+            if hasattr(visual, "_text"):
+                visual._text = None
+
+    def draw_tree(self) -> None:
+        """Once the data is added, draw the tree."""
+
+        self._subvisuals[0].set_data(
+            pos=np.row_stack([e.pos for e in self.edges]),
+            color=np.row_stack([e.safe_color for e in self.edges]),
+            connect=np.concatenate([e.connex for e in self.edges]),
+        )
+
+        # TextVisual does not have a ``set_data`` method
+        self._subvisuals[1].pos = np.asarray([a.pos for a in self.annotations])
+        self._subvisuals[1].text = [a.text for a in self.annotations]

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -26,7 +26,6 @@ class Bounds:
 @dataclass
 class TrackSubvisualProxy:
     pos: np.ndarray
-    width: int = 3
     color: np.ndarray = np.array([1.0, 1.0, 1.0, 1.0])
 
     @property
@@ -273,7 +272,6 @@ class TreeVisualFast(scene.visuals.Compound):
             subvisual_proxy = TrackSubvisualProxy(
                 pos=pos,
                 color=np.array([1.0, 1.0, 1.0, 1.0]),
-                width=3,
             )
         else:
             # Split up line into individual time steps so color can vary

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -194,7 +194,8 @@ class TreeVisual(scene.visuals.Compound):
             pos=[y, x, 0],
             anchor_x="left",
             anchor_y="top",
-            font_size=10,
+            font_size=6,
+            rotation=90,
         )
         self.add_subvisual(visual)
         self.subvisuals.append(visual)

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -100,6 +100,14 @@ class VisPyPlotter(TreePlotterQWidgetBase):
             width * (1 + 2 * padding),
             height * (1 + 2 * padding),
         )
+
+        # change the aspect ratio of the camera if we have just a single branch
+        # this will centre the camera on the single branch, otherwise, set the
+        # aspect ratio to match the data
+        if width == 0:
+            self.view.camera.aspect = 1.0
+        else:
+            self.view.camera.aspect = None
         self.view.camera.rect = rect
 
     def update_colors(self) -> None:

--- a/napari_arboretum/visualisation/vispy_plotter.py
+++ b/napari_arboretum/visualisation/vispy_plotter.py
@@ -11,6 +11,10 @@ from .base_plotter import TreePlotterQWidgetBase
 __all__ = ["VisPyPlotter"]
 
 
+DEFAULT_TEXT_SIZE = 8
+DEFAULT_BRANCH_WIDTH = 3
+
+
 @dataclass
 class Bounds:
     xmin: float
@@ -173,14 +177,16 @@ class TreeVisual(scene.visuals.Compound):
         """
 
         if id is None:
-            visual = scene.visuals.Line(pos=pos, color=color, width=3)
+            visual = scene.visuals.Line(
+                pos=pos, color=color, width=DEFAULT_BRANCH_WIDTH
+            )
         else:
             # Split up line into individual time steps so color can vary
             # along the line
             ys = np.arange(pos[0, 1], pos[1, 1] + 1)
             xs = np.ones(ys.size) * pos[0, 0]
             visual = scene.visuals.Line(
-                pos=np.column_stack((xs, ys)), color=color, width=3
+                pos=np.column_stack((xs, ys)), color=color, width=DEFAULT_BRANCH_WIDTH
             )
             self.tracks[id] = visual
 
@@ -194,7 +200,7 @@ class TreeVisual(scene.visuals.Compound):
             pos=[y, x, 0],
             anchor_x="left",
             anchor_y="top",
-            font_size=6,
+            font_size=DEFAULT_TEXT_SIZE,
             rotation=90,
         )
         self.add_subvisual(visual)
@@ -225,12 +231,12 @@ class TreeVisualFast(scene.visuals.Compound):
         self.annotations = []
 
         subvisuals = [
-            scene.visuals.Line(color="white", width=3),
+            scene.visuals.Line(color="white", width=DEFAULT_BRANCH_WIDTH),
             scene.visuals.Text(
                 anchor_x="left",
                 anchor_y="top",
                 rotation=90,
-                font_size=8,
+                font_size=DEFAULT_TEXT_SIZE,
                 color="white",
             ),
         ]


### PR DESCRIPTION
I did some profiling of the rendering code using `examples/show_large_tree.py` and 255 nodes (depth 8):

```sh
255 total nodes
         7509808 function calls (7448213 primitive calls) in 4.881 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.001    0.001    4.881    4.881 base_plotter.py:50(draw_from_nodes)
      892    0.005    0.000    4.370    0.005 visuals.py:125(__init__)
      509    0.002    0.000    2.784    0.005 vispy_plotter.py:110(add_branch)
      892    0.004    0.000    2.626    0.003 visual.py:325(__init__)
      509    0.004    0.000    2.552    0.005 vispy_plotter.py:156(add_track)
```

It looks like a lot of the time is in adding subvisuals, so I had a go at setting things up with a single subvisual for all branches. This gets the performance to a much better state:

```sh
255 total nodes
         121140 function calls (119670 primitive calls) in 0.138 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.140    0.140 base_plotter.py:50(draw_from_nodes)
      509    0.001    0.000    0.100    0.000 vispy_plotter.py:110(add_branch)
      509    0.006    0.000    0.086    0.000 vispy_plotter.py:88(autoscale_view)
6777/6009    0.023    0.000    0.046    0.000 {built-in method numpy.core._multiarray_umath.implement_array_function}
        1    0.009    0.009    0.036    0.036 tree.py:35(layout_tree)
```

0.14 seconds versus 4.88 seconds.  We will probably want to look at the graph searching algorithms at some point, but this is a good start.

This also merges the small changes in #77, so I will close that one.

![napari-arboretum](https://user-images.githubusercontent.com/8217795/175921897-e6897c4b-b081-4b60-92b5-0e3584433961.png)

