### PR TITLE
Added default factory to numpy color creation

### DIFF
--- a/src/napari_arboretum/tree.py
+++ b/src/napari_arboretum/tree.py
@@ -29,14 +29,14 @@ class Annotation:
     x: float
     y: float
     label: str
-    color: ColorType = field(default_factory=lambda : WHITE)
+    color: ColorType = field(default_factory=lambda: WHITE)
 
 
 @dataclass
 class Edge:
     x: tuple[float, float]
     y: tuple[float, float]
-    color: ColorType = field(default_factory=lambda : WHITE)
+    color: ColorType = field(default_factory=lambda: WHITE)
     track_id: int | None = None
     node: TreeNode | None = None
 

--- a/src/napari_arboretum/tree.py
+++ b/src/napari_arboretum/tree.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import itertools
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -29,14 +29,14 @@ class Annotation:
     x: float
     y: float
     label: str
-    color: ColorType = WHITE
+    color: ColorType = field(default_factory=lambda : WHITE)
 
 
 @dataclass
 class Edge:
     x: tuple[float, float]
     y: tuple[float, float]
-    color: ColorType = WHITE
+    color: ColorType = field(default_factory=lambda : WHITE)
     track_id: int | None = None
     node: TreeNode | None = None
 


### PR DESCRIPTION
Hey @quantumjot ,

I was getting this error:

```python3
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\site-packages\napari_arboretum\_hookimpls.py", line 1, in <module>
    from napari_arboretum.plugin import Arboretum
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\site-packages\napari_arboretum\plugin.py", line 10, in <module>
    from napari_arboretum.io.svg import export_svg
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\site-packages\napari_arboretum\io\svg.py", line 5, in <module>
    from napari_arboretum.tree import Annotation, Edge
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\site-packages\napari_arboretum\tree.py", line 27, in <module>
    @dataclass
     ^^^^^^^^^
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jordao\Mamba\envs\tracking\Lib\dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'numpy.ndarray'> for field color is not allowed: use default_factory
```

This PR fixes this issue. 